### PR TITLE
Allow specifying fluent clause IRIs

### DIFF
--- a/examples/models/pickplace_cart_product.bdd
+++ b/examples/models/pickplace_cart_product.bdd
@@ -23,14 +23,14 @@ Scenario Template (ns=bdd_tmpl) tmpl_pickplace {
     var place_ws
 
     Given:
-        holds(<target_object> is located at <pick_ws>, before <evt_pick_start>)
+        fc-located-before: holds(<target_object> is located at <pick_ws>, before <evt_pick_start>)
     When:
         Behaviour (ns=bdd_tmpl) pickplace {
             duration: from <evt_pick_start> until <evt_place_end>
             <robot> picks <target_object> and places at <place_ws>
         }
     Then:
-        holds(<target_object> is located at <place_ws>, after <evt_pick_start>)
+        fc-located-after: holds(<target_object> is located at <place_ws>, after <evt_pick_start>)
 }
 
 User Story (ns=bdd_var) sim_pickplace {

--- a/examples/models/pickplace_quantifiers.bdd
+++ b/examples/models/pickplace_quantifiers.bdd
@@ -25,7 +25,7 @@ Scenario Template (ns=bdd-tmpl) tmpl-sorting {
     for all ( var x in <target-objects> ) {
         Given:
         (
-            holds(<x> is located at <pick_ws>, before <evt_pick_start>)
+            fc-located-before: holds(<x> is located at <pick_ws>, before <evt_pick_start>)
         )
         When:
             Behaviour (ns=bdd-tmpl) pickplace {
@@ -35,11 +35,11 @@ Scenario Template (ns=bdd-tmpl) tmpl-sorting {
             }
         Then:
             ( var y exists in <place-workspaces> ) such that {
-                holds(<x> is located at <y>, after <evt_place_end>)
+                fc-located-after: holds(<x> is located at <y>, after <evt_place_end>)
             }
     }
     Then:
-        holds(<target-objects> are sorted into <place-workspaces>, after <evt_place_end>)
+        fc-sorted: holds(<target-objects> are sorted into <place-workspaces>, after <evt_place_end>)
 }
 
 User Story (ns=bdd-var) sim_sorting {

--- a/examples/models/pickplace_table.bdd
+++ b/examples/models/pickplace_table.bdd
@@ -19,7 +19,7 @@ Scenario Template (ns=bdd_tmpl) tmpl_pickplace {
     var place_ws
 
     Given:
-        holds(<target_object> is located at <pick_ws>, before <evt_pick_start>)
+        fc-located-before: holds(<target_object> is located at <pick_ws>, before <evt_pick_start>)
     When:
         Behaviour (ns=bdd_tmpl) pickplace {
             duration: from <evt_pick_start> until <evt_place_end>
@@ -27,9 +27,9 @@ Scenario Template (ns=bdd_tmpl) tmpl_pickplace {
         }
     Then:
         (
-            holds(<target_object> is located at <place_ws>, after <evt_pick_start>)
+            fc-located-after: holds(<target_object> is located at <place_ws>, after <evt_pick_start>)
             and
-            holds(<robot> can reach <target_object>, before <evt_pick_start>)
+            fc-reachable: holds(<robot> can reach <target_object>, before <evt_pick_start>)
         )
 }
 

--- a/examples/models/pickplace_table_new_predicates.bdd
+++ b/examples/models/pickplace_table_new_predicates.bdd
@@ -10,6 +10,7 @@ Event (ns=bdd_tmpl) evt_place_end
 Event (ns=bdd_tmpl) evt_scenario_end
 
 Scenario Template (ns=bdd_tmpl) tmpl_conveyor_sort {
+    duration: from <evt_scenario_start> until <evt_scenario_end>
     task: <tsk_pickplace>
 
     set var target_objects
@@ -19,23 +20,26 @@ Scenario Template (ns=bdd_tmpl) tmpl_conveyor_sort {
     var conveyor_speed
 
     Given:
-        holds(<conveyor> has config <conveyor_speed>, before <evt_scenario_start>)
+        fc-config: holds(<conveyor> has config <conveyor_speed>, before <evt_scenario_start>)
     for all ( var x in <target_objects> ) {
         Given:
         (
-            holds(<x> is located at <conveyor>, before <evt_pick_start>)
+            fc-located-before: holds(<x> is located at <conveyor>, before <evt_pick_start>)
             and
-            holds(<robot> can reach <x>, before <evt_pick_start>)
+            fc-reachable: holds(<robot> can reach <x>, before <evt_pick_start>)
         )
         When:
-            Behaviour (ns=bdd_tmpl) pickplace: <robot> picks <x> and places at <place_workspaces>
+            Behaviour (ns=bdd_tmpl) pickplace {
+                duration: from <evt_pick_start> until <evt_place_end>
+                <robot> picks <x> and places at <place_workspaces>
+            }
         Then:
             ( var y exists in <place_workspaces> ) such that {
-                holds(<x> is located at <y>, after <evt_place_end>)
+                fc-located-after: holds(<x> is located at <y>, after <evt_place_end>)
             }
     }
     Then:
-        holds(<target_objects> are sorted into <place_workspaces>, after <evt_place_end>)
+        fc-sorted: holds(<target_objects> are sorted into <place_workspaces>, after <evt_place_end>)
 }
 
 User Story (ns=bdd) us_pickplace_single_arm {
@@ -46,7 +50,7 @@ User Story (ns=bdd) us_pickplace_single_arm {
     Scenarios:
         Scenario simple_pick {
             template: <tmpl_conveyor_sort>
-            scene: <lab_scene>
+            scene: <sorting_scene>
 
             variation:
             | <tmpl_conveyor_sort.target_objects> |
@@ -55,8 +59,8 @@ User Story (ns=bdd) us_pickplace_single_arm {
               <tmpl_conveyor_sort.robot> |
               <tmpl_conveyor_sort.conveyor_speed> |
             |---|
-            | <lab_scene.box1> | <lab_scene.dining_table> | <lab_scene.shelf> | <lab_scene.freddy> | 0.9 |
-            | <lab_scene.ball> | <lab_scene.shelf> | <lab_scene.dining_table> | <lab_scene.lucy> | 1.0 |
-            | <lab_scene.bottle> | <lab_scene.dining_table> | <lab_scene.shelf> | <lab_scene.freddy> | 0.8 |
+            | <pickplace_objects.box1> | <lab_workspaces.table_ws> | <lab_workspaces.shelf_ws> | <isaac_agents.kinova> | 0.9 |
+            | <pickplace_objects.ball> | <lab_workspaces.shelf_ws> | <lab_workspaces.table_ws> | <isaac_agents.panda> | 1.0 |
+            | <pickplace_objects.bottle> | <lab_workspaces.table_ws> | <lab_workspaces.shelf_ws> | <isaac_agents.ur10> | 0.8 |
         }
 }

--- a/src/robbdd/classes/bdd.py
+++ b/src/robbdd/classes/bdd.py
@@ -116,7 +116,6 @@ class ScenarioSetVariable(VariableBase, SetBase):
 
 
 class TimeConstraint(IHasNamespace):
-
     def __init__(self, parent) -> None:
         super().__init__(parent=parent)
         self._uri = None
@@ -200,8 +199,9 @@ class HoldsExpr(FluentLogicExpr):
     tc: TimeConstraint
     _uri: Optional[URIRef]
 
-    def __init__(self, parent, predicate, tc) -> None:
+    def __init__(self, parent, name, predicate, tc) -> None:
         super().__init__(parent=parent)
+        self.name = name
         self.predicate = predicate
         self.tc = tc
         self._uri = None
@@ -209,9 +209,7 @@ class HoldsExpr(FluentLogicExpr):
     @property
     def uri(self) -> URIRef:
         if self._uri is None:
-            self._uri = self.namespace[
-                f"fc-{self.predicate.__class__.__name__}-{self.tc.__class__.__name__}-{self.uuid}"
-            ]
+            self._uri = self.namespace[self.name]
         return self._uri
 
 

--- a/src/robbdd/classes/bdd.py
+++ b/src/robbdd/classes/bdd.py
@@ -154,7 +154,7 @@ class DuringEvent(TimeConstraint):
         self.end_event = end_event
 
 
-class Clause(IHasUUID, IHasNamespace):
+class Clause(IHasNamespace):
     def __init__(self, parent) -> None:
         super().__init__(parent=parent)
 
@@ -213,7 +213,7 @@ class HoldsExpr(FluentLogicExpr):
         return self._uri
 
 
-class ExistsExpr(Clause):
+class ExistsExpr(Clause, IHasUUID):
     var: ScenarioVariable
     fl_expr: FluentLogicExpr
     _uri: Optional[URIRef]

--- a/src/robbdd/grammars/bdd.tx
+++ b/src/robbdd/grammars/bdd.tx
@@ -122,7 +122,7 @@ TextClause: text=STRING tc=TimeConstraint;
 // Fluent logic terms composing holds clauses with basic logic operators
 FluentLogicExpr: FluentAndExpr | FluentOrExpr | FluentNotExpr | HoldsExpr ;
 HoldsExpr:
-'holds' '(' predicate=FOLExpr ',' tc=TimeConstraint ')'
+name=IRI_TRUNK ':' 'holds' '(' predicate=FOLExpr ',' tc=TimeConstraint ')'
 ;
 FluentAndExpr:
 '('


### PR DESCRIPTION
* Instead of automatically generating IRIs with uuid, allow specifying name for fluent clauses (HoldsExpr), which enables linking from other context, e.g., to specify observation models or trinary ROS topics.
* Update all models so console generation & unit tests work.