### PR TITLE
Handle StringTemplate and HasConfiguration clauses

### DIFF
--- a/examples/models/pickplace_table_custom.bdd
+++ b/examples/models/pickplace_table_custom.bdd
@@ -1,0 +1,62 @@
+import "lab.scene"
+
+ns bdd_var='https://secorolab.github.io/models/acceptance-criteria/bdd/variants/pickplace-isaac/'
+ns bdd_tmpl='https://secorolab.github.io/models/acceptance-criteria/bdd/templates/'
+
+Task (ns=bdd_tmpl) tsk_pickplace
+Event (ns=bdd_tmpl) evt_scr_start
+Event (ns=bdd_tmpl) evt_scr_end
+Event (ns=bdd_tmpl) evt_pick_start
+Event (ns=bdd_tmpl) evt_place_end
+
+Scenario Template (ns=bdd_tmpl) tmpl_pickplace {
+    duration: from <evt_scr_start> until <evt_scr_end>
+    task: <tsk_pickplace>
+
+    var target_object
+    var robot
+    var pick_ws
+    var place_ws
+    var ee-speed
+
+    Given:
+        (
+        fc-located-before: holds(<target_object> is located at <pick_ws>, before <evt_pick_start>)
+        and
+        fc-config-robot: holds(<robot> has config ee_speed = <ee-speed>, before <evt_pick_start>)
+        )
+    When:
+        Behaviour (ns=bdd_tmpl) pickplace {
+            duration: from <evt_pick_start> until <evt_place_end>
+            <robot> picks <target_object> and places at <place_ws>
+        }
+    Then:
+        (
+            fc-located-after: holds(<target_object> is located at <place_ws>, after <evt_pick_start>)
+            and
+            fc-collide: holds(
+                pred(
+                    "\"{robot}\" does not collide with \"{pick_ws}\"", robot=<robot>, pick_ws=<pick_ws>
+                ), from <evt_pick_start> until <evt_place_end>
+            )
+        )
+}
+
+User Story (ns=bdd_var) sim_pickplace {
+    As A "Function Developer"
+    I Want "Pick and place behaviour"
+    So That "I can transport objects"
+
+    Scenarios:
+        Scenario pickplace_table {
+            template: <tmpl_pickplace>
+            scene: <pickplace_scene>
+
+            variation:
+            | <tmpl_pickplace.target_object> | <tmpl_pickplace.pick_ws> | <tmpl_pickplace.place_ws> | <tmpl_pickplace.robot> | <tmpl_pickplace.ee-speed> |
+            |---|
+            | <pickplace_objects.box1> | <lab_workspaces.table_ws> | <lab_workspaces.shelf_ws> |  <isaac_agents.panda> | 0.6 |
+            | <pickplace_objects.ball> | <lab_workspaces.shelf_ws> | <lab_workspaces.table_ws> |  <isaac_agents.ur10> | 0.7 |
+            | <pickplace_objects.bottle> | <lab_workspaces.table_ws> | <lab_workspaces.shelf_ws> | <isaac_agents.kinova> | 0.8 |
+        }
+}

--- a/examples/parse_bdd_specs.py
+++ b/examples/parse_bdd_specs.py
@@ -4,12 +4,13 @@ from sys import argv
 from os.path import abspath, dirname, join
 from urllib.request import HTTPError
 from rdf_utils.uri import URL_SECORO_M
+from rdflib import Literal, URIRef
 from textx import metamodel_for_language
 from rdf_utils.resolver import install_resolver
 from rdf_utils.naming import get_valid_filename
 from bdd_dsl.models.user_story import UserStoryLoader
 from bdd_dsl.utils.jinja import load_template_from_url, prepare_jinja2_template_data
-from robbdd.graph import create_bdd_model_graph
+from robbdd.graph import create_bdd_model_graph, get_var_value_node
 
 
 CWD = abspath(dirname(__file__))
@@ -56,12 +57,13 @@ def main():
             elif hasattr(var_set.val_set, "elems"):
                 elem_strings = []
                 for elem in var_set.val_set.elems:
-                    if elem.linked_val is not None:
-                        elem_strings.append(elem.linked_val.name)
-                    elif elem.literal_val is not None:
-                        elem_strings.append(elem.literal_val)
+                    node = get_var_value_node(var_val=elem)
+                    if isinstance(node, URIRef):
+                        elem_strings.append(node.n3())
+                    elif isinstance(node, Literal):
+                        elem_strings.append(str(node.toPython()))
                     else:
-                        raise ValueError(f"invalid element value: {elem}")
+                        raise ValueError(f"unhandled element type: {elem}")
                 print(
                     f"- of '{var_set.variable.name}':"
                     f" elems=({', '.join([x for x in elem_strings])})"

--- a/src/robbdd/grammars/bdd.tx
+++ b/src/robbdd/grammars/bdd.tx
@@ -145,7 +145,11 @@ AfterEvent: 'after' '<' event=[Event|FQN] '>';
 DuringEvent: 'from' '<' start_event=[Event|FQN] '>' 'until' '<' end_event=[Event|FQN] '>';
 
 // First Order Logic terms
-FOLExpr: LocatedAtPred | IsHeldPred | DoesNotDropPred | DoesNotCollidePred | CanReachPred | HasConfigPred | IsSortedPred ;
+FOLExpr:
+    StrTmplPred | LocatedAtPred | IsHeldPred | DoesNotDropPred | DoesNotCollidePred | CanReachPred | HasConfigPred | IsSortedPred
+;
+ArgVarMap: arg_name=ID '=' '<' arg_var=[VariableBase|FQN] '>';
+StrTmplPred: 'pred' '(' tmpl_str=STRING ',' arg_maps+=ArgVarMap[','] ')' ;
 CanReachPred:
     '<' agent=[VariableBase|FQN] '>' 'can' 'reach' '<' object=[VariableBase|FQN] '>'
 ;
@@ -162,7 +166,7 @@ IsHeldPred:
     '<' object=[VariableBase|FQN] '>' 'is' 'held' 'by' '<' agent=[VariableBase|FQN] '>'
 ;
 HasConfigPred:
-    '<' subject=[VariableBase|FQN] '>' 'has' 'config' '<' config=[VariableBase|FQN] '>'
+    '<' cfg_target=[VariableBase|FQN] '>' 'has' 'config' cfg_name=ID '=' '<' cfg_var=[VariableBase|FQN] '>'
 ;
 IsSortedPred:
     '<' objects=[ScenarioSetVariable|FQN] '>' 'are' 'sorted' 'into' '<' workspaces=[ScenarioSetVariable|FQN] '>'
@@ -257,6 +261,8 @@ ValidVarValue:
 |
 '<' linked_val=[Agent|FQN] '>'
 |
-literal_val=STRING|NUMBER|FLOAT
+num_val=NUMBER
+|
+str_val=STRING
 )
 ;

--- a/src/robbdd/graph.py
+++ b/src/robbdd/graph.py
@@ -14,6 +14,8 @@ from rdflib.collection import Collection
 from bdd_dsl.models.urirefs import (
     URI_AGN_PRED_HAS_AGN,
     URI_AGN_TYPE_AGN,
+    URI_BDD_PRED_ARG_NAMES,
+    URI_BDD_PRED_ARG_VARS,
     URI_BDD_PRED_CFG_NAME,
     URI_BDD_PRED_CFG_TARGET,
     URI_BDD_PRED_CFG_VAR,
@@ -33,6 +35,7 @@ from bdd_dsl.models.urirefs import (
     URI_BDD_PRED_REF_VAR,
     URI_BDD_PRED_REF_WS,
     URI_BDD_PRED_ROWS,
+    URI_BDD_PRED_TMPL_STR,
     URI_BDD_PRED_VAR_LIST,
     URI_BDD_TYPE_CART_PRODUCT,
     URI_BDD_TYPE_CONFIG,
@@ -249,6 +252,30 @@ def add_fc_predicate(graph: Graph, clause: HoldsExpr, clause_uri: URIRef):
 
     if "StrTmplPred" in pred_type_str:
         graph.add(triple=(clause_uri, RDF.type, URI_BDD_TYPE_STR_TMPL))
+
+        tmpl_str = getattr(clause.predicate, "tmpl_str", None)
+        assert isinstance(
+            tmpl_str, str
+        ), f"unexpected 'tmpl_str' attr for '{pred_type_str}' predicate of clause '{clause_uri}': {tmpl_str}"
+        graph.add(triple=(clause_uri, URI_BDD_PRED_TMPL_STR, Literal(tmpl_str)))
+
+        arg_maps = getattr(clause.predicate, "arg_maps", None)
+        assert isinstance(
+            arg_maps, list
+        ), f"unexpected 'arg_maps' attr for '{pred_type_str}' predicate of clause '{clause_uri}': {arg_maps}"
+
+        arg_names = []
+        arg_vars = []
+        for arg_m in arg_maps:
+            arg_names.append(arg_m.arg_name)
+            arg_vars.append(arg_m.arg_var.uri)
+        add_literal_list_pred(
+            graph=graph, subject_uri=clause_uri, pred_uri=URI_BDD_PRED_ARG_NAMES, values=arg_names
+        )
+        add_node_list_pred(
+            graph=graph, subject_uri=clause_uri, pred_uri=URI_BDD_PRED_ARG_VARS, nodes=arg_vars
+        )
+
         return
 
     if "IsSortedPred" in pred_type_str:

--- a/src/robbdd/graph.py
+++ b/src/robbdd/graph.py
@@ -14,6 +14,9 @@ from rdflib.collection import Collection
 from bdd_dsl.models.urirefs import (
     URI_AGN_PRED_HAS_AGN,
     URI_AGN_TYPE_AGN,
+    URI_BDD_PRED_CFG_NAME,
+    URI_BDD_PRED_CFG_TARGET,
+    URI_BDD_PRED_CFG_VAR,
     URI_BDD_PRED_CLAUSE_OF,
     URI_BDD_PRED_ELEMS,
     URI_BDD_PRED_HAS_AC,
@@ -32,6 +35,7 @@ from bdd_dsl.models.urirefs import (
     URI_BDD_PRED_ROWS,
     URI_BDD_PRED_VAR_LIST,
     URI_BDD_TYPE_CART_PRODUCT,
+    URI_BDD_TYPE_CONFIG,
     URI_BDD_TYPE_CONST_SET,
     URI_BDD_TYPE_EXISTS,
     URI_BDD_TYPE_FLUENT_CLAUSE,
@@ -43,6 +47,7 @@ from bdd_dsl.models.urirefs import (
     URI_BDD_PRED_WHEN,
     URI_BDD_PRED_THEN,
     URI_BDD_TYPE_GIVEN,
+    URI_BDD_TYPE_STR_TMPL,
     URI_BDD_TYPE_VARIABLE,
     URI_BDD_TYPE_SCENARIO_VARIANT,
     URI_BDD_TYPE_SCENE_AGN,
@@ -221,8 +226,29 @@ def add_fc_predicate(graph: Graph, clause: HoldsExpr, clause_uri: URIRef):
         return
 
     if "HasConfigPred" in pred_type_str:
-        # TODO(minhnh): handle predicate
-        graph.add(triple=(clause_uri, RDF.type, NS_MM_BDD["HasConfigPredicate"]))
+        graph.add(triple=(clause_uri, RDF.type, URI_BDD_TYPE_CONFIG))
+
+        cfg_name = getattr(clause.predicate, "cfg_name", None)
+        assert isinstance(
+            cfg_name, str
+        ), f"unexpected 'cfg_name' attr for '{pred_type_str}' predicate of clause '{clause_uri}': {cfg_name}"
+        graph.add(triple=(clause_uri, URI_BDD_PRED_CFG_NAME, Literal(cfg_name)))
+
+        cfg_target = getattr(clause.predicate, "cfg_target", None)
+        assert isinstance(
+            cfg_target, VariableBase
+        ), f"unexpected 'cfg_target' attr for '{pred_type_str}' predicate of clause '{clause_uri}': {cfg_target}"
+        graph.add(triple=(clause_uri, URI_BDD_PRED_CFG_TARGET, cfg_target.uri))
+
+        cfg_var = getattr(clause.predicate, "cfg_var", None)
+        assert isinstance(
+            cfg_var, VariableBase
+        ), f"unexpected 'cfg_var' attr for '{pred_type_str}' predicate of clause '{clause_uri}': {cfg_var}"
+        graph.add(triple=(clause_uri, URI_BDD_PRED_CFG_VAR, cfg_var.uri))
+        return
+
+    if "StrTmplPred" in pred_type_str:
+        graph.add(triple=(clause_uri, RDF.type, URI_BDD_TYPE_STR_TMPL))
         return
 
     if "IsSortedPred" in pred_type_str:
@@ -465,8 +491,11 @@ def get_var_value_node(var_val: Any) -> Node:
         assert var_val.linked_val.uri is not None
         return var_val.linked_val.uri
 
-    if hasattr(var_val, "literal_val") and var_val.literal_val is not None:
-        return Literal(var_val.literal_val)
+    if hasattr(var_val, "num_val") and var_val.num_val is not None:
+        return Literal(var_val.num_val)
+
+    if hasattr(var_val, "str_val") and var_val.str_val is not None:
+        return Literal(var_val.str_val)
 
     raise ValueError(f"ValidVarValue object has unhandled attributes: {var_val}")
 

--- a/tests/test_textx_languages.py
+++ b/tests/test_textx_languages.py
@@ -29,6 +29,7 @@ class TestTextXLanguages(unittest.TestCase):
             "pickplace_table.bdd",
             "pickplace_cart_product.bdd",
             "pickplace_quantifiers.bdd",
+            "pickplace_table_custom.bdd",
         ]:
             bdd_model = bdd_mm.model_from_file(join(MODELS_DIR, model_name))
             assert len(bdd_model.templates) > 0


### PR DESCRIPTION
This PR add graph generation for `HasConfig` & `StringTemplate` clauses.

* `StringTemplate` graph parsing depends on minhnh/bdd-dsl#36
* `HasConfig` graph parsing depends on minhnh/bdd-dsl#34
* Update `HasConfig` syntax to match JSON-LD model
* Gherkin generation for `HasConfig` clauses depends on minhnh/bdd-dsl#37
* Split string & numeric value for clearer handling of different variable value types