### PR TITLE
Support Variable Scene Elements

### DIFF
--- a/examples/models/lab.scene
+++ b/examples/models/lab.scene
@@ -40,10 +40,8 @@ scene (ns=scene_lab) pickplace_scene {
     obj set <pickplace_objects>
     ws comp <comp_table_pickplace>
     ws comp <comp_shelf_pickplace>
-    agn set <isaac_agents>
 }
 scene (ns=scene_lab) sorting_scene {
     obj set <pickplace_objects>
     ws comp <comp_table_sort>
-    agn set <isaac_agents>
 }

--- a/examples/parse_bdd_specs.py
+++ b/examples/parse_bdd_specs.py
@@ -61,8 +61,9 @@ def main():
 
             elif hasattr(var_set.val_set, "elems"):
                 elem_strings = []
+                set_uris = set()
                 for elem in var_set.val_set.elems:
-                    node = get_var_value_node(var_val=elem)
+                    node = get_var_value_node(graph=g, var_val=elem, set_uris=set_uris)
                     if isinstance(node, URIRef):
                         elem_strings.append(node.n3())
                     elif isinstance(node, Literal):

--- a/src/robbdd/classes/scene.py
+++ b/src/robbdd/classes/scene.py
@@ -69,7 +69,12 @@ class Agent(IHasNamespace):
         return self._uri
 
 
-class ObjectSet(SetBase, IHasNamespaceDeclare):
+class SceneSet(SetBase, IHasNamespaceDeclare):
+    def __init__(self, parent, ns, name) -> None:
+        super().__init__(parent=parent, ns=ns, name=name)
+
+
+class ObjectSet(SceneSet):
     objects: list[Object]
 
     def __init__(self, parent, ns, name, objects) -> None:
@@ -77,7 +82,7 @@ class ObjectSet(SetBase, IHasNamespaceDeclare):
         self.objects = objects
 
 
-class WorkspaceSet(SetBase, IHasNamespaceDeclare):
+class WorkspaceSet(SceneSet):
     workspaces: list[Workspace]
 
     def __init__(self, parent, ns, name, workspaces) -> None:
@@ -85,7 +90,7 @@ class WorkspaceSet(SetBase, IHasNamespaceDeclare):
         self.workspaces = workspaces
 
 
-class AgentSet(SetBase, IHasNamespaceDeclare):
+class AgentSet(SceneSet):
     agents: list[Agent]
 
     def __init__(self, parent, ns, name, agents) -> None:

--- a/src/robbdd/rdf/bdd.py
+++ b/src/robbdd/rdf/bdd.py
@@ -58,7 +58,7 @@ from robbdd.classes.bdd import (
     VariableBase,
 )
 from robbdd.classes.common import SetBase
-from robbdd.classes.scene import AgentSet, ObjectSet, SceneModel, WorkspaceSet
+from robbdd.classes.scene import AgentSet, ObjectSet, SceneModel, SceneSet, WorkspaceSet
 from robbdd.rdf.clauses import add_clause_expr, add_gwt_expr, add_node_time_constraint
 from robbdd.rdf.common import add_node_list_pred
 from robbdd.rdf.scene import add_scene_model, add_scene_set
@@ -107,11 +107,18 @@ def add_scenario_tmpl(graph: Graph, tmpl: ScenarioTemplate):
     graph.add(triple=(tmpl.scenario_uri, URI_BHV_PRED_OF_BHV, bhv_uri))
 
 
-def get_var_value_node(var_val: Any) -> Node:
+def get_var_value_node(graph: Graph, var_val: Any, set_uris: set[URIRef]) -> Node:
     if hasattr(var_val, "linked_val") and var_val.linked_val is not None:
         assert hasattr(
             var_val.linked_val, "uri"
         ), f"Linked value has no URI attr: {var_val.linked_val}"
+
+        # Add scene sets, in case they're not included explicitly by ScenarioVariant
+        if hasattr(var_val.linked_val, "parent") and isinstance(
+            var_val.linked_val.parent, SceneSet
+        ):
+            add_scene_set(graph=graph, scene_set=var_val.linked_val.parent, set_uris=set_uris)
+
         assert var_val.linked_val.uri is not None
         return var_val.linked_val.uri
 
@@ -135,21 +142,21 @@ def add_explicit_set(graph: Graph, const_set: ExplicitSet, set_uris: set[URIRef]
             triple=(
                 const_set.uri,
                 URI_BDD_PRED_ELEMS,
-                get_var_value_node(var_val=v),
+                get_var_value_node(graph=graph, var_val=v, set_uris=set_uris),
             )
         )
     set_uris.add(const_set.uri)
     return const_set.uri
 
 
-def get_set_expr_set(graph: Graph, set_expr: Any) -> IdentifiedNode:
+def get_set_expr_set(graph: Graph, set_expr: Any, set_uris: set[URIRef]) -> IdentifiedNode:
     assert (
         hasattr(set_expr, "elems") and set_expr.elems is not None
     ), f"SetExpr object has invalid 'elems' attr: {set_expr}"
     col_first = BNode()
     col = Collection(graph=graph, uri=col_first, seq=[])
     for elem in set_expr.elems:
-        col.append(get_var_value_node(var_val=elem))
+        col.append(get_var_value_node(graph=graph, var_val=elem, set_uris=set_uris))
     return col_first
 
 
@@ -162,30 +169,27 @@ def add_const_set(
     if isinstance(set_obj, ObjectSet):
         add_scene_set(
             graph=graph,
-            scn_comp_uri=scene_model.scene_obj_uri,
-            scn_set_uri=set_obj.uri,
-            set_elems=set_obj.objects,
+            scene_set=set_obj,
             set_uris=set_uris,
+            scn_comp_uri=scene_model.scene_obj_uri,
         )
         return set_obj.uri
 
     if isinstance(set_obj, WorkspaceSet):
         add_scene_set(
             graph=graph,
-            scn_comp_uri=scene_model.scene_ws_uri,
-            scn_set_uri=set_obj.uri,
-            set_elems=set_obj.workspaces,
+            scene_set=set_obj,
             set_uris=set_uris,
+            scn_comp_uri=scene_model.scene_ws_uri,
         )
         return set_obj.uri
 
     if isinstance(set_obj, AgentSet):
         add_scene_set(
             graph=graph,
-            scn_comp_uri=scene_model.scene_agn_uri,
-            scn_set_uri=set_obj.uri,
-            set_elems=set_obj.agents,
+            scene_set=set_obj,
             set_uris=set_uris,
+            scn_comp_uri=scene_model.scene_agn_uri,
         )
         return set_obj.uri
 
@@ -222,7 +226,7 @@ def add_task_variation(
             for i, v in enumerate(r.values):
                 var = variation.header.variables[i]
                 if "ValidVarValue" in v.__class__.__name__:
-                    var_value = get_var_value_node(var_val=v)
+                    var_value = get_var_value_node(graph=graph, var_val=v, set_uris=set_uris)
                     if isinstance(var, ScenarioSetVariable):
                         raise ValueError(
                             f"ScenarioSetVariable '{var.name}' assigned a non-set value: {var_value}"
@@ -251,7 +255,7 @@ def add_task_variation(
                 elif "SetExpr" in v.__class__.__name__:
                     if isinstance(var, ScenarioVariable):
                         raise ValueError(f"ScenarioVariable '{var.name}' assigned a set value")
-                    r_col.append(get_set_expr_set(graph=graph, set_expr=v))
+                    r_col.append(get_set_expr_set(graph=graph, set_expr=v, set_uris=set_uris))
                 else:
                     raise ValueError(
                         f"unhandled value type '{v.__class__.__name__}' in table variation for '{variation.uri}'"
@@ -268,13 +272,17 @@ def add_task_variation(
             var_list_col.append(v_set.variable.uri)
             if hasattr(v_set.val_set, "elems"):
                 # explicit set
-                sets_col.append(get_set_expr_set(graph=graph, set_expr=v_set.val_set))
+                sets_col.append(
+                    get_set_expr_set(graph=graph, set_expr=v_set.val_set, set_uris=set_uris)
+                )
             elif hasattr(v_set.val_set, "sets"):
                 # set of sets
                 set_of_sets_first = BNode()
                 set_of_sets_col = Collection(graph=graph, uri=set_of_sets_first, seq=[])
                 for set_expr in v_set.val_set.sets:
-                    set_of_sets_col.append(get_set_expr_set(graph=graph, set_expr=set_expr))
+                    set_of_sets_col.append(
+                        get_set_expr_set(graph=graph, set_expr=set_expr, set_uris=set_uris)
+                    )
                 sets_col.append(set_of_sets_first)
 
             elif hasattr(v_set.val_set, "linked_set"):
@@ -380,19 +388,21 @@ def add_scenario_variant(
         add_scene_model(graph=graph, scene=variant.scene, set_uris=set_uris)
         scenes.add(variant.scene.uri)
 
-    graph.add(triple=(variant.uri, URI_BDD_PRED_HAS_SCENE, variant.scene.scene_obj_uri))
-    graph.add(triple=(variant.uri, URI_BDD_PRED_HAS_SCENE, variant.scene.scene_ws_uri))
-    graph.add(triple=(variant.uri, URI_BDD_PRED_HAS_SCENE, variant.scene.scene_agn_uri))
-
-    graph.add(
-        triple=(variant.scene.scene_obj_uri, URI_BDD_PRED_OF_SCENE, variant.template.scene_uri)
-    )
-    graph.add(
-        triple=(variant.scene.scene_ws_uri, URI_BDD_PRED_OF_SCENE, variant.template.scene_uri)
-    )
-    graph.add(
-        triple=(variant.scene.scene_agn_uri, URI_BDD_PRED_OF_SCENE, variant.template.scene_uri)
-    )
+    if len(variant.scene.obj_sets) > 0:
+        graph.add(triple=(variant.uri, URI_BDD_PRED_HAS_SCENE, variant.scene.scene_obj_uri))
+        graph.add(
+            triple=(variant.scene.scene_obj_uri, URI_BDD_PRED_OF_SCENE, variant.template.scene_uri)
+        )
+    if len(variant.scene.ws_sets) > 0 or len(variant.scene.ws_comps) > 0:
+        graph.add(triple=(variant.uri, URI_BDD_PRED_HAS_SCENE, variant.scene.scene_ws_uri))
+        graph.add(
+            triple=(variant.scene.scene_ws_uri, URI_BDD_PRED_OF_SCENE, variant.template.scene_uri)
+        )
+    if len(variant.scene.agn_sets) > 0:
+        graph.add(triple=(variant.uri, URI_BDD_PRED_HAS_SCENE, variant.scene.scene_agn_uri))
+        graph.add(
+            triple=(variant.scene.scene_agn_uri, URI_BDD_PRED_OF_SCENE, variant.template.scene_uri)
+        )
 
     # variation
     add_task_variation(

--- a/src/robbdd/rdf/bdd.py
+++ b/src/robbdd/rdf/bdd.py
@@ -384,21 +384,24 @@ def add_scenario_variant(
     graph.add(triple=(variant.uri, URI_BDD_PRED_OF_TMPL, variant.template.uri))
 
     # scene
+    scn_has_obj, scn_has_ws, scn_has_agn = False, False, False
     if variant.scene.uri not in scenes:
-        add_scene_model(graph=graph, scene=variant.scene, set_uris=set_uris)
+        scn_has_obj, scn_has_ws, scn_has_agn = add_scene_model(
+            graph=graph, scene=variant.scene, set_uris=set_uris
+        )
         scenes.add(variant.scene.uri)
 
-    if len(variant.scene.obj_sets) > 0:
+    if scn_has_obj:
         graph.add(triple=(variant.uri, URI_BDD_PRED_HAS_SCENE, variant.scene.scene_obj_uri))
         graph.add(
             triple=(variant.scene.scene_obj_uri, URI_BDD_PRED_OF_SCENE, variant.template.scene_uri)
         )
-    if len(variant.scene.ws_sets) > 0 or len(variant.scene.ws_comps) > 0:
+    if scn_has_ws:
         graph.add(triple=(variant.uri, URI_BDD_PRED_HAS_SCENE, variant.scene.scene_ws_uri))
         graph.add(
             triple=(variant.scene.scene_ws_uri, URI_BDD_PRED_OF_SCENE, variant.template.scene_uri)
         )
-    if len(variant.scene.agn_sets) > 0:
+    if scn_has_agn:
         graph.add(triple=(variant.uri, URI_BDD_PRED_HAS_SCENE, variant.scene.scene_agn_uri))
         graph.add(
             triple=(variant.scene.scene_agn_uri, URI_BDD_PRED_OF_SCENE, variant.template.scene_uri)

--- a/src/robbdd/rdf/scene.py
+++ b/src/robbdd/rdf/scene.py
@@ -98,15 +98,11 @@ def add_ws_comp(
         add_ws_comp(graph=graph, scene=scene, ws_comp=child_comp, ws_comp_set=ws_comp_set)
 
 
-def add_scene_model(graph: Graph, scene: SceneModel, set_uris: set[URIRef]):
+def add_scene_model(
+    graph: Graph, scene: SceneModel, set_uris: set[URIRef]
+) -> tuple[bool, bool, bool]:
+    """Add elements of a scene model to the graph and returns whether the scene has objects, workspaces, and/or agents"""
     graph.bind(prefix=scene.ns_prefix, namespace=scene.namespace)
-
-    if len(scene.obj_sets) > 0:
-        graph.add(triple=(scene.scene_obj_uri, RDF.type, URI_BDD_TYPE_SCENE_OBJ))
-    if len(scene.ws_sets) > 0 or len(scene.ws_comps) > 0:
-        graph.add(triple=(scene.scene_ws_uri, RDF.type, URI_BDD_TYPE_SCENE_WS))
-    if len(scene.agn_sets) > 0:
-        graph.add(triple=(scene.scene_agn_uri, RDF.type, URI_BDD_TYPE_SCENE_AGN))
 
     for obj_set in scene.obj_sets:
         add_scene_set(
@@ -134,6 +130,23 @@ def add_scene_model(graph: Graph, scene: SceneModel, set_uris: set[URIRef]):
 
     for ws_comp in scene.ws_comps:
         add_ws_comp(graph=graph, scene=scene, ws_comp=ws_comp, ws_comp_set=None)
+
+    scene_has_obj = (
+        graph.value(subject=scene.scene_obj_uri, predicate=URI_ENV_PRED_HAS_OBJ) is not None
+    )
+    scene_has_ws = (
+        graph.value(subject=scene.scene_ws_uri, predicate=URI_ENV_PRED_HAS_WS) is not None
+    )
+    scene_has_agn = (
+        graph.value(subject=scene.scene_agn_uri, predicate=URI_AGN_PRED_HAS_AGN) is not None
+    )
+    if scene_has_obj:
+        graph.add(triple=(scene.scene_obj_uri, RDF.type, URI_BDD_TYPE_SCENE_OBJ))
+    if scene_has_ws:
+        graph.add(triple=(scene.scene_ws_uri, RDF.type, URI_BDD_TYPE_SCENE_WS))
+    if scene_has_agn > 0:
+        graph.add(triple=(scene.scene_agn_uri, RDF.type, URI_BDD_TYPE_SCENE_AGN))
+    return scene_has_obj, scene_has_ws, scene_has_agn
 
 
 def create_scene_model_graph(model: Any, g: Optional[Graph] = None) -> Graph:

--- a/src/robbdd/rdf/scene.py
+++ b/src/robbdd/rdf/scene.py
@@ -18,33 +18,48 @@ from bdd_dsl.models.urirefs import (
     URI_ENV_TYPE_WS_OBJ,
     URI_ENV_TYPE_WS_WS,
 )
-from robbdd.classes.scene import Agent, Object, SceneModel, Workspace, WorkspaceComposition
+from robbdd.classes.scene import (
+    AgentSet,
+    ObjectSet,
+    SceneModel,
+    SceneSet,
+    WorkspaceComposition,
+    WorkspaceSet,
+)
 
 
 def add_scene_set(
-    graph: Graph, scn_comp_uri: URIRef, scn_set_uri: URIRef, set_elems: list, set_uris: set[URIRef]
+    graph: Graph, scene_set: SceneSet, set_uris: set[URIRef], scn_comp_uri: Optional[URIRef] = None
 ):
-    if scn_set_uri in set_uris:
+    if scene_set.uri in set_uris:
         return
 
-    graph.add(triple=(scn_set_uri, RDF.type, URI_BDD_TYPE_SET))
-    graph.add(triple=(scn_set_uri, RDF.type, URI_BDD_TYPE_CONST_SET))
-    for elem in set_elems:
-        if isinstance(elem, Object):
-            graph.add(triple=(elem.uri, RDF.type, URI_ENV_TYPE_OBJ))
-            graph.add(triple=(scn_comp_uri, URI_ENV_PRED_HAS_OBJ, elem.uri))
-        elif isinstance(elem, Workspace):
-            graph.add(triple=(elem.uri, RDF.type, URI_ENV_TYPE_WS))
-            graph.add(triple=(scn_comp_uri, URI_ENV_PRED_HAS_WS, elem.uri))
-        elif isinstance(elem, Agent):
-            graph.add(triple=(elem.uri, RDF.type, URI_AGN_TYPE_AGN))
-            graph.add(triple=(scn_comp_uri, URI_AGN_PRED_HAS_AGN, elem.uri))
-        else:
-            raise ValueError(f"unhandled elem type: {elem}")
+    graph.add(triple=(scene_set.uri, RDF.type, URI_BDD_TYPE_SET))
+    graph.add(triple=(scene_set.uri, RDF.type, URI_BDD_TYPE_CONST_SET))
+    graph.bind(prefix=scene_set.ns_prefix, namespace=scene_set.namespace)
 
-        graph.add(triple=(scn_set_uri, URI_BDD_PRED_ELEMS, elem.uri))
+    if isinstance(scene_set, ObjectSet):
+        for obj in scene_set.objects:
+            graph.add(triple=(obj.uri, RDF.type, URI_ENV_TYPE_OBJ))
+            graph.add(triple=(scene_set.uri, URI_BDD_PRED_ELEMS, obj.uri))
+            if scn_comp_uri is not None:
+                graph.add(triple=(scn_comp_uri, URI_ENV_PRED_HAS_OBJ, obj.uri))
+    elif isinstance(scene_set, WorkspaceSet):
+        for ws in scene_set.workspaces:
+            graph.add(triple=(ws.uri, RDF.type, URI_ENV_TYPE_WS))
+            graph.add(triple=(scene_set.uri, URI_BDD_PRED_ELEMS, ws.uri))
+            if scn_comp_uri is not None:
+                graph.add(triple=(scn_comp_uri, URI_ENV_PRED_HAS_WS, ws.uri))
+    elif isinstance(scene_set, AgentSet):
+        for agn in scene_set.agents:
+            graph.add(triple=(agn.uri, RDF.type, URI_AGN_TYPE_AGN))
+            graph.add(triple=(scene_set.uri, URI_BDD_PRED_ELEMS, agn.uri))
+            if scn_comp_uri is not None:
+                graph.add(triple=(scn_comp_uri, URI_AGN_PRED_HAS_AGN, agn.uri))
+    else:
+        raise ValueError(f"Unhandled SceneSet type: {type(scene_set)}")
 
-    set_uris.add(scn_set_uri)
+    set_uris.add(scene_set.uri)
 
 
 def add_ws_comp(
@@ -86,38 +101,36 @@ def add_ws_comp(
 def add_scene_model(graph: Graph, scene: SceneModel, set_uris: set[URIRef]):
     graph.bind(prefix=scene.ns_prefix, namespace=scene.namespace)
 
-    graph.add(triple=(scene.scene_obj_uri, RDF.type, URI_BDD_TYPE_SCENE_OBJ))
+    if len(scene.obj_sets) > 0:
+        graph.add(triple=(scene.scene_obj_uri, RDF.type, URI_BDD_TYPE_SCENE_OBJ))
+    if len(scene.ws_sets) > 0 or len(scene.ws_comps) > 0:
+        graph.add(triple=(scene.scene_ws_uri, RDF.type, URI_BDD_TYPE_SCENE_WS))
+    if len(scene.agn_sets) > 0:
+        graph.add(triple=(scene.scene_agn_uri, RDF.type, URI_BDD_TYPE_SCENE_AGN))
+
     for obj_set in scene.obj_sets:
         add_scene_set(
             graph=graph,
-            scn_comp_uri=scene.scene_obj_uri,
-            scn_set_uri=obj_set.uri,
-            set_elems=obj_set.objects,
+            scene_set=obj_set,
             set_uris=set_uris,
+            scn_comp_uri=scene.scene_obj_uri,
         )
-        graph.bind(prefix=obj_set.ns_prefix, namespace=obj_set.namespace)
 
-    graph.add(triple=(scene.scene_ws_uri, RDF.type, URI_BDD_TYPE_SCENE_WS))
     for ws_set in scene.ws_sets:
         add_scene_set(
             graph=graph,
-            scn_comp_uri=scene.scene_ws_uri,
-            scn_set_uri=ws_set.uri,
-            set_elems=ws_set.workspaces,
+            scene_set=ws_set,
             set_uris=set_uris,
+            scn_comp_uri=scene.scene_ws_uri,
         )
-        graph.bind(prefix=ws_set.ns_prefix, namespace=ws_set.namespace)
 
-    graph.add(triple=(scene.scene_agn_uri, RDF.type, URI_BDD_TYPE_SCENE_AGN))
     for agn_set in scene.agn_sets:
         add_scene_set(
             graph=graph,
-            scn_comp_uri=scene.scene_agn_uri,
-            scn_set_uri=agn_set.uri,
-            set_elems=agn_set.agents,
+            scene_set=agn_set,
             set_uris=set_uris,
+            scn_comp_uri=scene.scene_agn_uri,
         )
-        graph.bind(prefix=agn_set.ns_prefix, namespace=agn_set.namespace)
 
     for ws_comp in scene.ws_comps:
         add_ws_comp(graph=graph, scene=scene, ws_comp=ws_comp, ws_comp_set=None)

--- a/src/robbdd/templates/robbdd.feature.jinja
+++ b/src/robbdd/templates/robbdd.feature.jinja
@@ -1,5 +1,6 @@
-# This file is a clone of an online version maintained at
-# https://github.com/minhnh/models-bdd/blob/-/jinja/feature.jinja
+{# This file is a clone of an online version maintained at
+   https://github.com/minhnh/models-bdd/blob/-/jinja/feature.jinja
+#}# Generated using minhnh/robbdd
 Feature: {{ data.name }}
 
 {%- for scenario_data in data.criteria %}

--- a/src/robbdd/templates/robbdd.feature.jinja
+++ b/src/robbdd/templates/robbdd.feature.jinja
@@ -1,35 +1,41 @@
 # This file is a clone of an online version maintained at
 # https://github.com/minhnh/models-bdd/blob/-/jinja/feature.jinja
 Feature: {{ data.name }}
-{%- if 'scene' in data %}
-  Background:
-    {%- if 'objects' in data.scene %}
-    Given a set of objects
-      | name |
-      {% for obj_name in data.scene.objects -%}
-        | {{ obj_name }} |
-      {% endfor %}
-    {%- endif -%}
-    {%- if 'workspaces' in data.scene %}
-    Given a set of workspaces
-      | name |
-      {% for ws_name in data.scene.workspaces -%}
-        | {{ ws_name }} |
-      {% endfor %}
-    {%- endif -%}
-    {%- if 'agents' in data.scene %}
-    Given a set of agents
-      | name |
-      {% for agn_name in data.scene.agents -%}
-        | {{ agn_name }} |
-      {% endfor %}
-    {%- endif %}
-    Given the scene is set up
-{%- endif %}
 
 {%- for scenario_data in data.criteria %}
 {% for var_data in scenario_data.variations %}
   Scenario: {{ var_data.name }}
+    {%- if 'scene' in var_data %}
+    {%- if 'objects' in var_data.scene %}
+    Given a set of objects
+      | name |
+      {% for obj_name in var_data.scene.objects -%}
+        | {{ obj_name }} |
+      {% endfor %}
+    {%- endif -%}
+    {%- if 'workspaces' in var_data.scene %}
+    Given a set of workspaces
+      | name |
+      {% for ws_name in var_data.scene.workspaces -%}
+        | {{ ws_name }} |
+      {% endfor %}
+    {%- endif -%}
+    {%- if 'agents' in var_data.scene %}
+    Given a set of agents
+      | name |
+      {% for agn_name in var_data.scene.agents -%}
+        | {{ agn_name }} |
+      {% endfor %}
+    {%- endif %}
+    {%- if 'elements' in var_data.scene %}
+    Given variable scene elements
+      | name |
+      {% for elem_name in var_data.scene.elements -%}
+        | {{ elem_name }} |
+      {% endfor %}
+    {%- endif %}
+    Given the scene is set up
+    {%- endif %}
     {% for clause in var_data.clauses%}
     {{ clause|safe }}{% endfor %}
 {% endfor %}


### PR DESCRIPTION
This refactor scene graph & gherkin model processing/generation matching support of variable scene elements introduced in minhnh/bdd-dsl#43 and minhnh/models-bdd#7. The commit includes:

- Add SceneSet abstraction for sets of objects, workspaces & agents.
- Call add_scene_set() on parent of any elements linked in scenario variations, either in table cells or inline set expressions.
- Move namespace binding to add_scene_set().
- Remove agent set from scene as covered via scenario variable.
- Model processing depends on changes from minhnh/bdd-dsl#43.
- Copy Gherkin template changes from minhnh/models-bdd#7